### PR TITLE
Correcting phantom basic script to ensures it works as stated in the doc

### DIFF
--- a/lib/phantom/basic.js
+++ b/lib/phantom/basic.js
@@ -26,7 +26,7 @@ if (system.args.length < 3) {
         // Write HTML to file
         fs.write(output, page.content, 'w');
         phantom.exit();
-      }, interval);
+      }, timeout);
     }
   });
 }


### PR DESCRIPTION
From the docs :

> If value is basic, it runs the basic.js script found under lib/phantom/. This script basically takes a HTML snapshot after the timeout.

However, previously the snapshot was taken after 'interval', not after 'timeout'

